### PR TITLE
Config key 'exclude' absence fix

### DIFF
--- a/src/Prettus/RequestLogger/Middlewares/ResponseLoggerMiddleware.php
+++ b/src/Prettus/RequestLogger/Middlewares/ResponseLoggerMiddleware.php
@@ -40,6 +40,10 @@ class ResponseLoggerMiddleware
 
     protected function excluded(Request $request) {
         $exclude = config('request-logger.exclude');
+		
+		if (null === $exclude || empty($exclude)) {
+			return false;
+		}
 
         foreach($exclude as $path) {
             if($request->is($path)) return true;


### PR DESCRIPTION
When there is no any 'exclude' key in the config file, irrelevant error
had been thrown. This PR is to fix these issues; #4, #5 and #7.